### PR TITLE
fix: 修复全局系统预设导致对话卡住的 UTF-8 字节边界崩溃

### DIFF
--- a/src-tauri/src/commands/conversations.rs
+++ b/src-tauri/src/commands/conversations.rs
@@ -2346,7 +2346,7 @@ pub async fn send_message(
         tracing::info!(
             "[send_message] model={} effective_system_prompt='{}'",
             &conversation.model_id,
-            &sys[..sys.len().min(80)]
+            &sys[..sys.floor_char_boundary(sys.len().min(80))]
         );
         chat_messages.push(ChatMessage {
             role: if no_system_role {


### PR DESCRIPTION
使用 floor_char_boundary 替代直接字节索引切片，确保对中文
system prompt 截断时不会在多字节字符中间切断导致 panic。

Bug: 发送消息时 &sys[..80] 对中文 system prompt 在字节 80
处切断了多字节字符 '小'（3字节），触发 panic 使 send_message
任务崩溃，对话卡住。