### PR TITLE
feat: 绘图API兼容URL响应 + 新增自定义接口配置

### DIFF
--- a/src-tauri/crates/providers/src/openai_images.rs
+++ b/src-tauri/crates/providers/src/openai_images.rs
@@ -33,6 +33,8 @@ pub struct ImageEditRequest {
     pub background: Option<String>,
     pub output_compression: Option<u8>,
     pub transfer_mode: ImageEditTransferMode,
+    pub image_format: ImageEditImageFormat,
+    pub image_param_name: String,
     pub images: Vec<ImageUpload>,
     pub mask: Option<ImageUpload>,
 }
@@ -43,36 +45,17 @@ pub enum ImageEditTransferMode {
     Base64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImageEditImageFormat {
+    Object,
+    String,
+}
+
 #[derive(Debug, Clone)]
 pub struct ImageUpload {
     pub bytes: Vec<u8>,
     pub file_name: String,
     pub mime_type: String,
-}
-
-#[derive(Debug, Clone, Serialize)]
-struct ImageEditJsonRequest {
-    model: String,
-    prompt: String,
-    n: u8,
-    size: String,
-    quality: String,
-    output_format: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    background: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    output_compression: Option<u8>,
-    images: Vec<ImageInputReference>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    mask: Option<ImageInputReference>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-struct ImageInputReference {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    file_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    image_url: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -124,12 +107,14 @@ impl OpenAIImagesClient {
         format!("{}{}", Self::base_url(ctx).trim_end_matches('/'), suffix)
     }
 
-    fn generate_url(ctx: &ProviderRequestContext) -> String {
-        Self::image_url(ctx, "/images/generations")
+    fn generate_url(ctx: &ProviderRequestContext, path: Option<&str>) -> String {
+        let default_path = "/images/generations";
+        Self::image_url(ctx, path.unwrap_or(default_path))
     }
 
-    fn edit_url(ctx: &ProviderRequestContext) -> String {
-        Self::image_url(ctx, "/images/edits")
+    fn edit_url(ctx: &ProviderRequestContext, path: Option<&str>) -> String {
+        let default_path = "/images/edits";
+        Self::image_url(ctx, path.unwrap_or(default_path))
     }
 
     fn get_client(&self, ctx: &ProviderRequestContext) -> Result<reqwest::Client> {
@@ -143,10 +128,11 @@ impl OpenAIImagesClient {
         &self,
         ctx: &ProviderRequestContext,
         request: ImageGenerateRequest,
+        path: Option<&str>,
     ) -> Result<ImageApiOutput> {
         let client = self.get_client(ctx)?;
         let builder = client
-            .post(Self::generate_url(ctx))
+            .post(Self::generate_url(ctx, path))
             .bearer_auth(&ctx.api_key)
             .json(&request);
         let response = apply_request_headers(builder, ctx)
@@ -160,16 +146,20 @@ impl OpenAIImagesClient {
         &self,
         ctx: &ProviderRequestContext,
         request: ImageEditRequest,
+        path: Option<&str>,
     ) -> Result<ImageApiOutput> {
         let client = self.get_client(ctx)?;
         let builder = client
-            .post(Self::edit_url(ctx))
+            .post(Self::edit_url(ctx, path))
             .bearer_auth(&ctx.api_key);
         let builder = match request.transfer_mode {
             ImageEditTransferMode::Multipart => {
                 builder.multipart(build_edit_multipart_form(request)?)
             }
-            ImageEditTransferMode::Base64 => builder.json(&build_edit_json_request(request)),
+            ImageEditTransferMode::Base64 => {
+                let body = build_edit_json_request(request)?;
+                builder.body(body).header("Content-Type", "application/json")
+            }
         };
         let response = apply_request_headers(builder, ctx)
             .send()
@@ -212,31 +202,86 @@ fn build_edit_multipart_form(request: ImageEditRequest) -> Result<reqwest::multi
     Ok(form)
 }
 
-fn image_upload_to_reference(upload: ImageUpload) -> ImageInputReference {
+fn image_upload_to_string(upload: ImageUpload) -> String {
     let data = base64::engine::general_purpose::STANDARD.encode(upload.bytes);
-    ImageInputReference {
-        file_id: None,
-        image_url: Some(format!("data:{};base64,{}", upload.mime_type, data)),
-    }
+    format!("data:{};base64,{}", upload.mime_type, data)
 }
 
-fn build_edit_json_request(request: ImageEditRequest) -> ImageEditJsonRequest {
-    ImageEditJsonRequest {
-        model: request.model,
-        prompt: request.prompt,
-        n: request.n,
-        size: request.size,
-        quality: request.quality,
-        output_format: request.output_format,
-        background: request.background,
-        output_compression: request.output_compression,
-        images: request
-            .images
-            .into_iter()
-            .map(image_upload_to_reference)
-            .collect(),
-        mask: request.mask.map(image_upload_to_reference),
+fn build_edit_json_request(request: ImageEditRequest) -> Result<Vec<u8>> {
+    let mut map = serde_json::Map::new();
+    map.insert("model".to_string(), serde_json::Value::String(request.model));
+    map.insert("prompt".to_string(), serde_json::Value::String(request.prompt));
+    map.insert("n".to_string(), serde_json::Value::Number(request.n.into()));
+    map.insert("size".to_string(), serde_json::Value::String(request.size));
+    map.insert("quality".to_string(), serde_json::Value::String(request.quality));
+    map.insert(
+        "output_format".to_string(),
+        serde_json::Value::String(request.output_format),
+    );
+
+    if let Some(background) = request.background {
+        map.insert(
+            "background".to_string(),
+            serde_json::Value::String(background),
+        );
     }
+    if let Some(output_compression) = request.output_compression {
+        map.insert(
+            "output_compression".to_string(),
+            serde_json::Value::Number(output_compression.into()),
+        );
+    }
+
+    if request.images.is_empty() {
+        return Err(AQBotError::Provider(
+            "No image provided for edit request".into(),
+        ));
+    }
+
+    match request.image_format {
+
+        ImageEditImageFormat::Object => {
+            let images: Vec<serde_json::Value> = request
+                .images
+                .into_iter()
+                .map(|upload| {
+                    let mut obj = serde_json::Map::new();
+                    obj.insert(
+                        "url".to_string(),
+                        serde_json::Value::String(image_upload_to_string(upload)),
+                    );
+                    serde_json::Value::Object(obj)
+                })
+                .collect();
+            map.insert(
+                request.image_param_name,
+                serde_json::Value::Array(images),
+            );
+        }
+        ImageEditImageFormat::String => {
+            let images: Vec<serde_json::Value> = request
+                .images
+                .into_iter()
+                .map(|upload| serde_json::Value::String(image_upload_to_string(upload)))
+                .collect();
+            map.insert(
+                request.image_param_name,
+                serde_json::Value::Array(images),
+            );
+        }
+    }
+
+    if let Some(mask) = request.mask {
+        map.insert(
+            "mask".to_string(),
+            serde_json::Value::String(image_upload_to_string(mask)),
+        );
+    }
+
+    let value = serde_json::Value::Object(map);
+    serde_json::to_vec(&value).map_err(|e| {
+        AQBotError::Provider(format!("Failed to serialize edit request: {}", e))
+    })
 }
 
 async fn parse_response(response: reqwest::Response) -> Result<ImageApiOutput> {
@@ -309,17 +354,17 @@ mod tests {
         let ctx = context_with_chat_path();
 
         assert_eq!(
-            OpenAIImagesClient::generate_url(&ctx),
+            OpenAIImagesClient::generate_url(&ctx, None),
             "https://api.openai.com/v1/images/generations"
         );
         assert_eq!(
-            OpenAIImagesClient::edit_url(&ctx),
+            OpenAIImagesClient::edit_url(&ctx, None),
             "https://api.openai.com/v1/images/edits"
         );
     }
 
     #[test]
-    fn edit_request_body_serializes_images_as_base64_data_urls() {
+    fn edit_request_body_serializes_images_as_object_array_format() {
         let body = build_edit_json_request(ImageEditRequest {
             model: "gpt-image-2".to_string(),
             prompt: "换成马斯克".to_string(),
@@ -330,18 +375,58 @@ mod tests {
             background: Some("auto".to_string()),
             output_compression: None,
             transfer_mode: ImageEditTransferMode::Base64,
+            image_format: ImageEditImageFormat::Object,
+            image_param_name: "images".to_string(),
             images: vec![ImageUpload {
                 bytes: b"abc".to_vec(),
                 file_name: "reference.jpg".to_string(),
                 mime_type: "image/jpeg".to_string(),
             }],
             mask: None,
-        });
+        })
+        .expect("build edit json request");
 
-        let value = serde_json::to_value(body).expect("edit JSON body");
+        let value: serde_json::Value =
+            serde_json::from_slice(&body).expect("parse json body");
         assert_eq!(value["model"], "gpt-image-2");
         assert_eq!(value["prompt"], "换成马斯克");
-        assert_eq!(value["images"][0]["image_url"], "data:image/jpeg;base64,YWJj");
+        assert_eq!(value["images"][0]["url"], "data:image/jpeg;base64,YWJj");
+        assert!(value.get("mask").is_none());
+
+        let serialized = value.to_string();
+        assert!(!serialized.contains("image[]"));
+        assert!(!serialized.contains("reference.jpg"));
+        assert!(!serialized.contains("bytes"));
+    }
+
+    #[test]
+    fn edit_request_body_serializes_images_as_string_array() {
+        let body = build_edit_json_request(ImageEditRequest {
+            model: "gpt-image-2".to_string(),
+            prompt: "换成马斯克".to_string(),
+            n: 1,
+            size: "1024x1024".to_string(),
+            quality: "high".to_string(),
+            output_format: "png".to_string(),
+            background: Some("auto".to_string()),
+            output_compression: None,
+            transfer_mode: ImageEditTransferMode::Base64,
+            image_format: ImageEditImageFormat::String,
+            image_param_name: "images".to_string(),
+            images: vec![ImageUpload {
+                bytes: b"abc".to_vec(),
+                file_name: "reference.jpg".to_string(),
+                mime_type: "image/jpeg".to_string(),
+            }],
+            mask: None,
+        })
+        .expect("build edit json request");
+
+        let value: serde_json::Value =
+            serde_json::from_slice(&body).expect("parse json body");
+        assert_eq!(value["model"], "gpt-image-2");
+        assert_eq!(value["prompt"], "换成马斯克");
+        assert_eq!(value["images"][0], "data:image/jpeg;base64,YWJj");
         assert!(value.get("mask").is_none());
 
         let serialized = value.to_string();
@@ -362,6 +447,8 @@ mod tests {
             background: None,
             output_compression: Some(80),
             transfer_mode: ImageEditTransferMode::Base64,
+            image_format: ImageEditImageFormat::String,
+            image_param_name: "images".to_string(),
             images: vec![
                 ImageUpload {
                     bytes: b"source".to_vec(),
@@ -379,13 +466,18 @@ mod tests {
                 file_name: "mask.png".to_string(),
                 mime_type: "image/png".to_string(),
             }),
-        });
+        })
+        .expect("build edit json request");
 
-        let value = serde_json::to_value(body).expect("edit JSON body");
-        assert_eq!(value["images"].as_array().expect("images array").len(), 2);
-        assert_eq!(value["images"][0]["image_url"], "data:image/png;base64,c291cmNl");
-        assert_eq!(value["images"][1]["image_url"], "data:image/webp;base64,cmVm");
-        assert_eq!(value["mask"]["image_url"], "data:image/png;base64,bWFzaw==");
+        let value: serde_json::Value =
+            serde_json::from_slice(&body).expect("parse json body");
+        assert_eq!(
+            value["images"].as_array().expect("images array").len(),
+            2
+        );
+        assert_eq!(value["images"][0], "data:image/png;base64,c291cmNl");
+        assert_eq!(value["images"][1], "data:image/webp;base64,cmVm");
+        assert_eq!(value["mask"], "data:image/png;base64,bWFzaw==");
         assert_eq!(value["output_compression"], 80);
         assert!(value.get("background").is_none());
 
@@ -393,6 +485,36 @@ mod tests {
         assert!(!serialized.contains("image[]"));
         assert!(!serialized.contains("file_name"));
         assert!(!serialized.contains("mime_type"));
+    }
+
+    #[test]
+    fn edit_request_with_custom_image_param_name() {
+        let body = build_edit_json_request(ImageEditRequest {
+            model: "gpt-image-2".to_string(),
+            prompt: "生成图片".to_string(),
+            n: 1,
+            size: "1024x1024".to_string(),
+            quality: "high".to_string(),
+            output_format: "png".to_string(),
+            background: None,
+            output_compression: None,
+            transfer_mode: ImageEditTransferMode::Base64,
+            image_format: ImageEditImageFormat::String,
+            image_param_name: "image_urls".to_string(),
+            images: vec![ImageUpload {
+                bytes: b"test".to_vec(),
+                file_name: "test.jpg".to_string(),
+                mime_type: "image/jpeg".to_string(),
+            }],
+            mask: None,
+        })
+        .expect("build edit json request");
+
+        let value: serde_json::Value =
+            serde_json::from_slice(&body).expect("parse json body");
+        assert!(value.get("image_urls").is_some());
+        assert!(value.get("images").is_none());
+        assert_eq!(value["image_urls"][0], "data:image/jpeg;base64,dGVzdA==");
     }
 
     #[tokio::test]
@@ -476,6 +598,8 @@ mod tests {
                     background: None,
                     output_compression: None,
                     transfer_mode: ImageEditTransferMode::Multipart,
+                    image_format: ImageEditImageFormat::String,
+                    image_param_name: "images".to_string(),
                     images: vec![ImageUpload {
                         bytes: b"abc".to_vec(),
                         file_name: "reference.jpg".to_string(),
@@ -483,6 +607,7 @@ mod tests {
                     }],
                     mask: None,
                 },
+                None,
             )
             .await
             .expect("edit response");

--- a/src-tauri/crates/providers/src/openai_images.rs
+++ b/src-tauri/crates/providers/src/openai_images.rs
@@ -99,6 +99,7 @@ struct ImageApiResponse {
 #[derive(Deserialize)]
 struct ImageData {
     b64_json: Option<String>,
+    url: Option<String>,
     revised_prompt: Option<String>,
 }
 
@@ -252,14 +253,28 @@ async fn parse_response(response: reqwest::Response) -> Result<ImageApiOutput> {
         .await
         .map_err(|e| AQBotError::Provider(format!("Invalid image API response: {}", e)))?;
 
+    let client = reqwest::Client::new();
     let mut images = Vec::with_capacity(body.data.len());
     for item in body.data {
-        let encoded = item
-            .b64_json
-            .ok_or_else(|| AQBotError::Provider("Image API response missing b64_json".into()))?;
-        let bytes = base64::engine::general_purpose::STANDARD
-            .decode(encoded)
-            .map_err(|e| AQBotError::Provider(format!("Invalid image b64_json: {}", e)))?;
+        let bytes = if let Some(encoded) = item.b64_json {
+            base64::engine::general_purpose::STANDARD
+                .decode(encoded)
+                .map_err(|e| AQBotError::Provider(format!("Invalid image b64_json: {}", e)))?
+        } else if let Some(url) = item.url {
+            client
+                .get(&url)
+                .send()
+                .await
+                .map_err(|e| AQBotError::Provider(format!("Failed to fetch image from URL: {}", e)))?
+                .bytes()
+                .await
+                .map_err(|e| AQBotError::Provider(format!("Failed to read image bytes: {}", e)))?
+                .to_vec()
+        } else {
+            return Err(AQBotError::Provider(
+                "Image API response missing both b64_json and url".into(),
+            ));
+        };
         images.push(ImageApiImage {
             bytes,
             revised_prompt: item.revised_prompt,

--- a/src-tauri/src/commands/drawing.rs
+++ b/src-tauri/src/commands/drawing.rs
@@ -6,7 +6,7 @@ use aqbot_core::repo::drawing::{
 use aqbot_core::repo::stored_file::StoredFile;
 use aqbot_core::types::{ProviderConfig, ProviderProxyConfig, ProviderType};
 use aqbot_providers::openai_images::{
-    ImageEditRequest, ImageEditTransferMode, ImageGenerateRequest, ImageUpload, OpenAIImagesClient,
+    ImageEditImageFormat, ImageEditRequest, ImageEditTransferMode, ImageGenerateRequest, ImageUpload, OpenAIImagesClient,
 };
 use aqbot_providers::{resolve_base_url_for_type, ProviderRequestContext};
 use base64::Engine;
@@ -38,7 +38,15 @@ pub struct DrawingGenerateInput {
     #[serde(default)]
     pub reference_image_mode: DrawingReferenceImageMode,
     #[serde(default)]
+    pub reference_image_format: DrawingReferenceImageFormat,
+    #[serde(default)]
+    pub reference_image_param_name: String,
+    #[serde(default)]
     pub reference_file_ids: Vec<String>,
+    #[serde(default)]
+    pub generation_api_path: String,
+    #[serde(default)]
+    pub edit_api_path: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -56,7 +64,15 @@ pub struct DrawingEditInput {
     #[serde(default)]
     pub reference_image_mode: DrawingReferenceImageMode,
     #[serde(default)]
+    pub reference_image_format: DrawingReferenceImageFormat,
+    #[serde(default)]
+    pub reference_image_param_name: String,
+    #[serde(default)]
     pub reference_file_ids: Vec<String>,
+    #[serde(default)]
+    pub generation_api_path: String,
+    #[serde(default)]
+    pub edit_api_path: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -75,7 +91,15 @@ pub struct DrawingMaskEditInput {
     #[serde(default)]
     pub reference_image_mode: DrawingReferenceImageMode,
     #[serde(default)]
+    pub reference_image_format: DrawingReferenceImageFormat,
+    #[serde(default)]
+    pub reference_image_param_name: String,
+    #[serde(default)]
     pub reference_file_ids: Vec<String>,
+    #[serde(default)]
+    pub generation_api_path: String,
+    #[serde(default)]
+    pub edit_api_path: String,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -96,6 +120,28 @@ impl From<DrawingReferenceImageMode> for ImageEditTransferMode {
         match value {
             DrawingReferenceImageMode::Multipart => ImageEditTransferMode::Multipart,
             DrawingReferenceImageMode::Base64 => ImageEditTransferMode::Base64,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DrawingReferenceImageFormat {
+    Object,
+    String,
+}
+
+impl Default for DrawingReferenceImageFormat {
+    fn default() -> Self {
+        Self::Object
+    }
+}
+
+impl From<DrawingReferenceImageFormat> for ImageEditImageFormat {
+    fn from(value: DrawingReferenceImageFormat) -> Self {
+        match value {
+            DrawingReferenceImageFormat::Object => ImageEditImageFormat::Object,
+            DrawingReferenceImageFormat::String => ImageEditImageFormat::String,
         }
     }
 }
@@ -189,6 +235,9 @@ pub async fn generate_drawing_images(
     )
     .await?;
 
+    let generation_path = if input.generation_api_path.is_empty() { None } else { Some(input.generation_api_path.as_str()) };
+    let edit_path = if input.edit_api_path.is_empty() { None } else { Some(input.edit_api_path.as_str()) };
+
     let result = if input.reference_file_ids.is_empty() {
         OpenAIImagesClient::new()
             .generate(
@@ -203,6 +252,7 @@ pub async fn generate_drawing_images(
                     background: input.background.clone(),
                     output_compression: input.output_compression,
                 },
+                generation_path,
             )
             .await
     } else {
@@ -220,9 +270,12 @@ pub async fn generate_drawing_images(
                     background: input.background.clone(),
                     output_compression: input.output_compression,
                     transfer_mode: input.reference_image_mode.into(),
+                    image_format: input.reference_image_format.into(),
+                    image_param_name: input.reference_image_param_name.clone(),
                     images: uploads,
                     mask: None,
                 },
+                edit_path,
             )
             .await
     };
@@ -263,6 +316,7 @@ pub async fn edit_drawing_image(
         None,
     )
     .await?;
+    let edit_path = if input.edit_api_path.is_empty() { None } else { Some(input.edit_api_path.as_str()) };
     let mut uploads = vec![load_drawing_image_upload(&state, &source).await?];
     uploads.extend(load_reference_uploads(&state, &input.reference_file_ids).await?);
     let result = OpenAIImagesClient::new()
@@ -278,9 +332,12 @@ pub async fn edit_drawing_image(
                 background: input.background.clone(),
                 output_compression: input.output_compression,
                 transfer_mode: input.reference_image_mode.into(),
+                image_format: input.reference_image_format.into(),
+                image_param_name: input.reference_image_param_name.clone(),
                 images: uploads,
                 mask: None,
             },
+            edit_path,
         )
         .await;
 
@@ -330,6 +387,7 @@ pub async fn edit_drawing_image_with_mask(
         Some(input.mask_file_id.clone()),
     )
     .await?;
+    let edit_path = if input.edit_api_path.is_empty() { None } else { Some(input.edit_api_path.as_str()) };
     let mut uploads = vec![load_drawing_image_upload(&state, &source).await?];
     uploads.extend(load_reference_uploads(&state, &input.reference_file_ids).await?);
     let mask = Some(load_stored_file_upload(&state, &mask_file).await?);
@@ -346,9 +404,12 @@ pub async fn edit_drawing_image_with_mask(
                 background: input.background.clone(),
                 output_compression: input.output_compression,
                 transfer_mode: input.reference_image_mode.into(),
+                image_format: input.reference_image_format.into(),
+                image_param_name: input.reference_image_param_name.clone(),
                 images: uploads,
                 mask,
             },
+            edit_path,
         )
         .await;
 

--- a/src/components/drawing/DrawingComposer.tsx
+++ b/src/components/drawing/DrawingComposer.tsx
@@ -155,8 +155,12 @@ export function DrawingComposer({ settings, prompt, onPromptChange, onHeightChan
         background: settings.background,
         output_compression: settings.outputCompression,
         reference_image_mode: settings.referenceImageMode,
+        reference_image_format: settings.referenceImageFormat,
+        reference_image_param_name: settings.referenceImageParamName,
         n: settings.n,
         reference_file_ids: references.map((item) => item.id),
+        generation_api_path: settings.generationApiPath,
+        edit_api_path: settings.editApiPath,
       };
       onPromptChange('');
       if (editSourceImage && editMaskFileId) {

--- a/src/components/drawing/DrawingSettingsPanel.tsx
+++ b/src/components/drawing/DrawingSettingsPanel.tsx
@@ -1,6 +1,6 @@
-import { Form, InputNumber, Select, Slider, Switch, Typography, theme } from 'antd';
+import { Collapse, Form, Input, InputNumber, Select, Slider, Switch, Typography, theme } from 'antd';
 import { useTranslation } from 'react-i18next';
-import type { DrawingReferenceImageMode, DrawingSettings, ProviderConfig } from '@/types';
+import type { DrawingReferenceImageFormat, DrawingReferenceImageMode, DrawingSettings, ProviderConfig } from '@/types';
 import {
   getDrawingBackgroundOptions,
   getDrawingModelOptions,
@@ -65,94 +65,134 @@ export function DrawingSettingsPanel({ settings, providers, onChange }: Props) {
       }}
     >
       <Form layout="vertical">
-        <Form.Item label={t('drawing.model', '模型')}>
-          <Select
-            value={settings.modelId}
-            options={modelOptions}
-            placeholder={t('drawing.selectModel', '选择绘图模型')}
-            onChange={(modelId) => {
-              const nextProviders = getDrawingProvidersForModel(providers, modelId);
-              const providerId = nextProviders.some((provider) => provider.id === settings.providerId)
-                ? settings.providerId
-                : nextProviders[0]?.id ?? '';
-              patch({
-                modelId,
-                providerId,
-              });
-            }}
-          />
-        </Form.Item>
-        <Form.Item label={t('drawing.provider', 'Provider')}>
-          <Select
-            value={settings.providerId || undefined}
-            placeholder={t('drawing.selectProvider', '选择服务商')}
-            options={providerOptions}
-            optionLabelProp="label"
-            onChange={(providerId) => patch({ providerId })}
-          />
-        </Form.Item>
-        <Form.Item label={t('drawing.size', '尺寸')}>
-          <Select
-            value={settings.size}
-            options={getDrawingSizeOptions(translateOption)}
-            onChange={(size) => patch({ size })}
-          />
-        </Form.Item>
-        <Form.Item label={t('drawing.quality', '质量')}>
-          <Select
-            value={settings.quality}
-            options={getDrawingQualityOptions(translateOption)}
-            onChange={(quality) => patch({ quality })}
-          />
-        </Form.Item>
-        <Form.Item label={t('drawing.outputFormat', '输出格式')}>
-          <Select
-            value={settings.outputFormat}
-            options={getDrawingOutputFormatOptions(translateOption)}
-            onChange={(outputFormat) => patch({ outputFormat })}
-          />
-        </Form.Item>
-        <Form.Item label={t('drawing.background', '背景')}>
-          <Select
-            value={settings.background}
-            options={backgroundOptions}
-            onChange={(background) => patch({ background })}
-          />
-        </Form.Item>
-        <Form.Item label={t('drawing.batchCount', '批量张数')}>
-          <InputNumber
-            min={1}
-            max={10}
-            value={settings.n}
-            style={{ width: '100%' }}
-            onChange={(n) => patch({ n: n || 1 })}
-          />
-        </Form.Item>
-        <Form.Item label={t('drawing.referenceImageMode', '参考图发送方式')}>
-          <Select<DrawingReferenceImageMode>
-            value={settings.referenceImageMode}
-            options={referenceImageModeOptions}
-            onChange={(referenceImageMode) => patch({ referenceImageMode })}
-          />
-        </Form.Item>
-        {compressionVisible && (
-          <Form.Item label={t('drawing.compression', '压缩')}>
-            <div className="flex items-center gap-3">
-              <Switch
-                checked={settings.outputCompression !== undefined}
-                onChange={(checked) => patch({ outputCompression: checked ? 90 : undefined })}
+        <Collapse defaultActiveKey={['basic']} ghost>
+          <Collapse.Panel header={t('drawing.basicSettings', '基础设置')} key="basic">
+            <Form.Item label={t('drawing.model', '模型')}>
+              <Select
+                value={settings.modelId}
+                options={modelOptions}
+                placeholder={t('drawing.selectModel', '选择绘图模型')}
+                onChange={(modelId) => {
+                  const nextProviders = getDrawingProvidersForModel(providers, modelId);
+                  const providerId = nextProviders.some((provider) => provider.id === settings.providerId)
+                    ? settings.providerId
+                    : nextProviders[0]?.id ?? '';
+                  patch({
+                    modelId,
+                    providerId,
+                  });
+                }}
               />
-              <Slider
-                min={0}
-                max={100}
-                disabled={settings.outputCompression === undefined}
-                value={settings.outputCompression ?? 90}
-                onChange={(outputCompression) => patch({ outputCompression })}
-                style={{ flex: 1 }}
+            </Form.Item>
+            <Form.Item label={t('drawing.provider', 'Provider')}>
+              <Select
+                value={settings.providerId || undefined}
+                placeholder={t('drawing.selectProvider', '选择服务商')}
+                options={providerOptions}
+                optionLabelProp="label"
+                onChange={(providerId) => patch({ providerId })}
               />
-            </div>
-          </Form.Item>
-        )}
+            </Form.Item>
+            <Form.Item label={t('drawing.size', '尺寸')}>
+              <Select
+                value={settings.size}
+                options={getDrawingSizeOptions(translateOption)}
+                onChange={(size) => patch({ size })}
+              />
+            </Form.Item>
+            <Form.Item label={t('drawing.quality', '质量')}>
+              <Select
+                value={settings.quality}
+                options={getDrawingQualityOptions(translateOption)}
+                onChange={(quality) => patch({ quality })}
+              />
+            </Form.Item>
+            <Form.Item label={t('drawing.outputFormat', '输出格式')}>
+              <Select
+                value={settings.outputFormat}
+                options={getDrawingOutputFormatOptions(translateOption)}
+                onChange={(outputFormat) => patch({ outputFormat })}
+              />
+            </Form.Item>
+            <Form.Item label={t('drawing.background', '背景')}>
+              <Select
+                value={settings.background}
+                options={backgroundOptions}
+                onChange={(background) => patch({ background })}
+              />
+            </Form.Item>
+            <Form.Item label={t('drawing.batchCount', '批量张数')}>
+              <InputNumber
+                min={1}
+                max={10}
+                value={settings.n}
+                style={{ width: '100%' }}
+                onChange={(n) => patch({ n: n || 1 })}
+              />
+            </Form.Item>
+          </Collapse.Panel>
+          <Collapse.Panel header={t('drawing.advancedSettings', '高级设置')} key="advanced">
+            <Form.Item label={t('drawing.generationApiPath', '生图接口')}>
+              <Input
+                value={settings.generationApiPath}
+                placeholder="/images/generations"
+                onChange={(e) => patch({ generationApiPath: e.target.value })}
+              />
+            </Form.Item>
+            <Form.Item label={t('drawing.editApiPath', '编辑接口')}>
+              <Input
+                value={settings.editApiPath}
+                placeholder="/images/edits"
+                onChange={(e) => patch({ editApiPath: e.target.value })}
+              />
+            </Form.Item>
+            <Form.Item label={t('drawing.referenceImageMode', '参考图发送方式')}>
+              <Select<DrawingReferenceImageMode>
+                value={settings.referenceImageMode}
+                options={referenceImageModeOptions}
+                onChange={(referenceImageMode) => patch({ referenceImageMode })}
+              />
+            </Form.Item>
+            <Form.Item label={t('drawing.referenceImageFormat', '参考图数据格式')}>
+              <Select<DrawingReferenceImageFormat>
+                value={settings.referenceImageFormat}
+                options={[
+                  { label: t('drawing.referenceImageFormat.object', '对象数组'), value: 'object' },
+                  { label: t('drawing.referenceImageFormat.string', '字符串数组'), value: 'string' },
+                ]}
+                onChange={(referenceImageFormat) => patch({ referenceImageFormat })}
+              />
+            </Form.Item>
+            <Form.Item label={t('drawing.referenceImageParamName', '图片参数名')}>
+              <Input
+                value={settings.referenceImageParamName}
+                placeholder="images"
+                onChange={(e) => patch({ referenceImageParamName: e.target.value })}
+              />
+              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                {t('drawing.referenceImageParamName.hint', '常用值: image, images, image_url, image_urls')}
+              </Typography.Text>
+            </Form.Item>
+            {compressionVisible && (
+              <Form.Item label={t('drawing.compression', '压缩')}>
+                <div className="flex items-center gap-3">
+                  <Switch
+                    checked={settings.outputCompression !== undefined}
+                    onChange={(checked) => patch({ outputCompression: checked ? 90 : undefined })}
+                  />
+                  <Slider
+                    min={0}
+                    max={100}
+                    disabled={settings.outputCompression === undefined}
+                    value={settings.outputCompression ?? 90}
+                    onChange={(outputCompression) => patch({ outputCompression })}
+                    style={{ flex: 1 }}
+                  />
+                </div>
+              </Form.Item>
+            )}
+          </Collapse.Panel>
+        </Collapse>
       </Form>
       <Typography.Text style={{ fontSize: 12, color: token.colorTextSecondary }}>
         {t('drawing.references', '参考图')}

--- a/src/components/drawing/__tests__/DrawingComposer.test.tsx
+++ b/src/components/drawing/__tests__/DrawingComposer.test.tsx
@@ -41,7 +41,11 @@ const settingsFixture: DrawingSettings = {
   background: 'auto',
   outputCompression: undefined,
   referenceImageMode: 'base64',
+  referenceImageFormat: 'object',
+  referenceImageParamName: 'image',
   n: 1,
+  generationApiPath: '/images/generations',
+  editApiPath: '/images/edits',
 };
 
 describe('DrawingComposer', () => {
@@ -104,6 +108,7 @@ describe('DrawingComposer', () => {
         mask_file_id: 'mask-1',
         prompt: '替换涂抹区域',
         reference_image_mode: 'base64',
+        reference_image_format: 'object',
       }));
     });
     expect(editImage).not.toHaveBeenCalled();

--- a/src/stores/__tests__/drawingStore.test.ts
+++ b/src/stores/__tests__/drawingStore.test.ts
@@ -62,6 +62,7 @@ describe('drawingStore', () => {
       background: 'auto',
       n: 10,
       reference_image_mode: 'multipart',
+      reference_image_format: 'object',
       reference_file_ids: [],
     });
 
@@ -139,6 +140,7 @@ describe('drawingStore', () => {
       background: 'auto',
       n: 4,
       reference_image_mode: 'multipart',
+      reference_image_format: 'object',
       reference_file_ids: [],
     });
 
@@ -181,6 +183,7 @@ describe('drawingStore', () => {
       background: 'auto',
       n: 1,
       reference_image_mode: 'multipart',
+      reference_image_format: 'object',
       reference_file_ids: [],
     });
 
@@ -259,6 +262,7 @@ describe('drawingStore', () => {
       source_image_id: 'source-image-1',
       mask_file_id: 'mask-1',
       reference_image_mode: 'multipart',
+      reference_image_format: 'object',
       reference_file_ids: ['ref-1'],
     });
 
@@ -301,6 +305,7 @@ describe('drawingStore', () => {
       background: 'auto',
       n: 1,
       reference_image_mode: 'multipart',
+      reference_image_format: 'object',
       reference_file_ids: [],
     });
 
@@ -336,6 +341,7 @@ describe('drawingStore', () => {
       source_image_id: 'image-1',
       mask_file_id: 'mask-1',
       reference_image_mode: 'multipart',
+      reference_image_format: 'object',
       reference_file_ids: [],
     });
 
@@ -370,6 +376,7 @@ describe('drawingStore', () => {
         background: 'auto',
         n: 1,
         reference_image_mode: 'multipart',
+      reference_image_format: 'object',
         reference_file_ids: ['ref-1'],
       }),
       reference_file_ids_json: '["ref-1"]',
@@ -387,6 +394,7 @@ describe('drawingStore', () => {
     expect(invokeMock).toHaveBeenCalledWith('generate_drawing_images', {
       input: expect.objectContaining({
         reference_image_mode: 'base64',
+        reference_image_format: 'object',
         reference_file_ids: ['ref-1'],
       }),
     });

--- a/src/stores/drawingSettingsStore.ts
+++ b/src/stores/drawingSettingsStore.ts
@@ -12,6 +12,7 @@ import type {
   DrawingModelId,
   DrawingOutputFormat,
   DrawingQuality,
+  DrawingReferenceImageFormat,
   DrawingReferenceImageMode,
   DrawingSettings,
 } from '@/types';
@@ -27,6 +28,7 @@ const DRAWING_QUALITIES = new Set<DrawingQuality>(['auto', 'low', 'medium', 'hig
 const DRAWING_OUTPUT_FORMATS = new Set<DrawingOutputFormat>(['png', 'jpeg', 'webp']);
 const DRAWING_BACKGROUNDS = new Set<DrawingBackground>(['auto', 'opaque', 'transparent']);
 const DRAWING_REFERENCE_MODES = new Set<DrawingReferenceImageMode>(DRAWING_REFERENCE_IMAGE_MODES);
+const DRAWING_REFERENCE_FORMATS = new Set<DrawingReferenceImageFormat>(['object', 'string']);
 
 export const DEFAULT_DRAWING_SETTINGS: DrawingSettings = {
   providerId: '',
@@ -37,7 +39,11 @@ export const DEFAULT_DRAWING_SETTINGS: DrawingSettings = {
   background: 'auto',
   outputCompression: undefined,
   referenceImageMode: 'multipart',
+  referenceImageFormat: 'object',
+  referenceImageParamName: 'image',
   n: 1,
+  generationApiPath: '/images/generations',
+  editApiPath: '/images/edits',
 };
 
 interface DrawingSettingsState {
@@ -65,6 +71,10 @@ function isDrawingBackground(value: unknown): value is DrawingBackground {
 
 function isDrawingReferenceImageMode(value: unknown): value is DrawingReferenceImageMode {
   return typeof value === 'string' && DRAWING_REFERENCE_MODES.has(value as DrawingReferenceImageMode);
+}
+
+function isDrawingReferenceImageFormat(value: unknown): value is DrawingReferenceImageFormat {
+  return typeof value === 'string' && DRAWING_REFERENCE_FORMATS.has(value as DrawingReferenceImageFormat);
 }
 
 function clampNumber(value: number, min: number, max: number): number {
@@ -107,9 +117,21 @@ export function normalizeDrawingSettings(settings: Partial<DrawingSettings> = {}
     referenceImageMode: isDrawingReferenceImageMode(settings.referenceImageMode)
       ? settings.referenceImageMode
       : DEFAULT_DRAWING_SETTINGS.referenceImageMode,
+    referenceImageFormat: isDrawingReferenceImageFormat(settings.referenceImageFormat)
+      ? settings.referenceImageFormat
+      : DEFAULT_DRAWING_SETTINGS.referenceImageFormat,
+    referenceImageParamName: typeof settings.referenceImageParamName === 'string' && settings.referenceImageParamName.trim() !== ''
+      ? settings.referenceImageParamName.trim()
+      : DEFAULT_DRAWING_SETTINGS.referenceImageParamName,
     n: typeof settings.n === 'number'
       ? clampNumber(Math.round(settings.n), MIN_BATCH_COUNT, MAX_BATCH_COUNT)
       : DEFAULT_DRAWING_SETTINGS.n,
+    generationApiPath: typeof settings.generationApiPath === 'string'
+      ? settings.generationApiPath
+      : DEFAULT_DRAWING_SETTINGS.generationApiPath,
+    editApiPath: typeof settings.editApiPath === 'string'
+      ? settings.editApiPath
+      : DEFAULT_DRAWING_SETTINGS.editApiPath,
   };
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -534,6 +534,7 @@ export type DrawingQuality = 'low' | 'medium' | 'high' | 'auto';
 export type DrawingOutputFormat = 'png' | 'jpeg' | 'webp';
 export type DrawingBackground = 'auto' | 'opaque' | 'transparent';
 export type DrawingReferenceImageMode = 'multipart' | 'base64';
+export type DrawingReferenceImageFormat = 'object' | 'string';
 
 export interface DrawingSettings {
   providerId: string;
@@ -544,7 +545,11 @@ export interface DrawingSettings {
   background: DrawingBackground;
   outputCompression?: number;
   referenceImageMode: DrawingReferenceImageMode;
+  referenceImageFormat: DrawingReferenceImageFormat;
+  referenceImageParamName: string;
   n: number;
+  generationApiPath: string;
+  editApiPath: string;
 }
 
 export interface DrawingStoredFile {
@@ -603,6 +608,9 @@ export interface DrawingGenerateInput {
   output_compression?: number;
   n: number;
   reference_image_mode: DrawingReferenceImageMode;
+  reference_image_format: DrawingReferenceImageFormat;
+  generation_api_path?: string;
+  edit_api_path?: string;
   reference_file_ids: string[];
 }
 


### PR DESCRIPTION
1. 适配图片接口url链接格式响应，自动下载远程图片资源，兼容主流服务商返回结构
2. 绘图模块新增自定义接口路由、图片参数名、参考图数据格式配置项
3. 优化配置页面交互，分层展示基础与高级配置
4. 完善参数校验与类型定义，统一前后端绘图请求格式，提升多API服务商 API接口请求体参数 适配性
已进行测试，测试通过
<img width="3000" height="2079" alt="image" src="https://github.com/user-attachments/assets/d37876c1-a492-4913-80f6-4b3070af859f" />

