### PR TITLE
chore: post-#123 cleanup for agent bash path

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[target.x86_64-pc-windows-gnu]
-linker = "x86_64-w64-mingw32-gcc"

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -495,7 +495,7 @@
     "agentWorkspaceDatetimeFormatDesc": "Supports YYYY, MM, DD, HH, mm, and ss. Invalid filename characters are replaced with -.",
     "agentWorkspacePreview": "Preview: {{value}}",
     "agentBashPath": "Bash Path",
-    "agentBashPathDesc": "Path to the Bash executable used for Agent commands. Leave empty to auto-detect from PATH.",
+    "agentBashPathDesc": "Path to the Bash executable used for Agent commands. Leave empty to auto-detect from PATH. On Windows with Git, use e.g. C:\\Program Files\\Git\\bin\\bash.exe (not git-bash.exe).",
     "agentBashPathPlaceholder": "Leave empty for auto-detection",
     "selectAgentBashPath": "Select Bash executable",
     "resetAgentBashPath": "Reset to auto-detection",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -495,7 +495,7 @@
     "agentWorkspaceDatetimeFormatDesc": "支持 YYYY、MM、DD、HH、mm、ss；非法文件名字符会自动替换为 -。",
     "agentWorkspacePreview": "预览：{{value}}",
     "agentBashPath": "Bash 路径",
-    "agentBashPathDesc": "Agent 执行命令时使用的 Bash 可执行文件路径。留空时自动从 PATH 检测。",
+    "agentBashPathDesc": "Agent 执行命令时使用的 Bash 可执行文件路径。留空时自动从 PATH 检测。Windows 上若安装了 Git，可填例如 C:\\Program Files\\Git\\bin\\bash.exe（不要选 git-bash.exe）。",
     "agentBashPathPlaceholder": "留空自动检测",
     "selectAgentBashPath": "选择 Bash 可执行文件",
     "resetAgentBashPath": "恢复自动检测",


### PR DESCRIPTION
## Summary

Follow-up after merging #123 / fixing #120:

- Remove machine-local `.cargo/config.toml` (mingw cross-compile linker — should not live in the main repo)
- Bump `open-agent-sdk` to include warn + unit tests when `shell_binary` path is missing
- Clarify Git Bash path examples in zh-CN / en-US settings copy

## Related

- Closes follow-up work for #123
- Related to #120 (already closed via merge of #123)

## Test plan

- [x] `cargo test --lib tools::bash::tests` in open-agent-sdk (6 passed)
- [ ] Confirm settings still show Bash Path after pull
- [ ] Confirm no `.cargo/config.toml` on main after merge