### PR TITLE
feat: add SkillManager tool for runtime skill management

### DIFF
--- a/src-tauri/crates/agent/src/permission.rs
+++ b/src-tauri/crates/agent/src/permission.rs
@@ -66,6 +66,7 @@ pub fn classify_tool_risk(tool_name: &str) -> RiskLevel {
             | "move"
             | "mkdir"
             | "remove"
+            | "skillmanager"
     ) || name_lower.contains("write")
         || name_lower.contains("edit")
         || name_lower.contains("create")

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -1024,7 +1024,10 @@ pub async fn agent_query(
     };
     let skill_registry = Arc::new(tokio::sync::RwLock::new(registry));
     let skill_tool: Arc<dyn open_agent_sdk::types::Tool> = Arc::new(
-        open_agent_sdk::tools::skill_tool::SkillTool::new(skill_registry),
+        open_agent_sdk::tools::skill_tool::SkillTool::new(skill_registry.clone()),
+    );
+    let skill_manager: Arc<dyn open_agent_sdk::types::Tool> = Arc::new(
+        open_agent_sdk::tools::skill_manager::SkillManager::new(home.clone(), skill_registry),
     );
 
     // Build ask_fn for AskUserQuestion tool
@@ -1084,7 +1087,7 @@ pub async fn agent_query(
         skills_summary,
         ask_fn: Some(ask_fn),
         can_use_tool: Some(can_use_tool),
-        custom_tools: vec![skill_tool],
+        custom_tools: vec![skill_tool, skill_manager],
         abort_signal: Some(cancel_token.clone()),
         shell_binary: global_settings.agent_bash_path.clone(),
         ..Default::default()


### PR DESCRIPTION
## Summary

Add a SkillManager tool that allows the agent to list, install, and remove skills at runtime. Skills are persisted to disk under ~/.aqbot/skills/ and registered in the in-memory SkillRegistry.

## Changes

- src-tauri/crates/agent/src/permission.rs -- Add skillmanager to write-level risk classification
- src-tauri/src/commands/agent.rs -- Register SkillManager as an agent tool
- src-tauri/crates/open-agent-sdk -- Submodule update: add SkillManager tool and SkillRegistry::remove()