### PR TITLE
fix(chat): 支持 OpenAI 兼容响应中的生成图片

### DIFF
--- a/src-tauri/crates/providers/src/openai_compat.rs
+++ b/src-tauri/crates/providers/src/openai_compat.rs
@@ -299,19 +299,58 @@ fn extract_primary_content(
     content: &Option<String>,
     extra: &std::collections::BTreeMap<String, serde_json::Value>,
 ) -> Option<String> {
-    if content.is_some() {
-        return content.clone();
-    }
-
-    for key in ["text", "part", "parts", "value", "output_text"] {
-        if let Some(value) = extra.get(key) {
-            if let Some(text) = extract_text_from_json(value) {
-                return Some(text);
+    let mut combined = content.clone().or_else(|| {
+        for key in ["text", "part", "parts", "value", "output_text"] {
+            if let Some(value) = extra.get(key) {
+                if let Some(text) = extract_text_from_json(value) {
+                    return Some(text);
+                }
             }
         }
+
+        None
+    });
+
+    if let Some(images) = extract_response_images(extra) {
+        let text = combined.get_or_insert_with(String::new);
+        if !text.is_empty() {
+            text.push_str("\n\n");
+        }
+        text.push_str(&images);
     }
 
-    None
+    combined.filter(|value| !value.is_empty())
+}
+
+fn extract_response_images(
+    extra: &std::collections::BTreeMap<String, serde_json::Value>,
+) -> Option<String> {
+    let images = extra.get("images")?.as_array()?;
+    let mut markdown = String::new();
+
+    for image in images {
+        let Some(image_url) = image.get("image_url") else {
+            continue;
+        };
+        let url = image_url
+            .as_str()
+            .or_else(|| image_url.get("url").and_then(serde_json::Value::as_str));
+        let Some(url) = url.filter(|url| {
+            url.get(.."data:image/".len())
+                .is_some_and(|prefix| prefix.eq_ignore_ascii_case("data:image/"))
+        }) else {
+            continue;
+        };
+
+        if !markdown.is_empty() {
+            markdown.push_str("\n\n");
+        }
+        markdown.push_str("![image](");
+        markdown.push_str(url);
+        markdown.push(')');
+    }
+
+    (!markdown.is_empty()).then_some(markdown)
 }
 
 fn extract_gemini_compat_chunk(data: &str) -> Option<ChatStreamChunk> {
@@ -974,6 +1013,76 @@ mod tests {
                     "image_url": { "url": "data:image/png;base64,YWJj" }
                 }
             ]))
+        );
+    }
+
+    #[test]
+    fn extracts_streamed_images_from_openai_compatible_delta() {
+        let response: OpenAIResponse = serde_json::from_value(json!({
+            "id": "image-response",
+            "model": "gemini-3.1-flash-image",
+            "choices": [{
+                "index": 0,
+                "delta": {
+                    "role": "assistant",
+                    "content": null,
+                    "images": [{
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "data:image/jpeg;base64,/9j/2Q=="
+                        },
+                        "index": 0
+                    }]
+                }
+            }]
+        }))
+        .expect("valid OpenAI-compatible image chunk");
+        let delta = response.choices[0].delta.as_ref().expect("stream delta");
+
+        assert_eq!(
+            extract_primary_content(&delta.content, &delta.extra).as_deref(),
+            Some("![image](data:image/jpeg;base64,/9j/2Q==)")
+        );
+    }
+
+    #[test]
+    fn combines_non_streamed_text_and_openai_compatible_images() {
+        let response: OpenAIResponse = serde_json::from_value(json!({
+            "id": "image-response",
+            "model": "gemini-3.1-flash-image",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "Generated image",
+                    "images": [
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": "data:image/png;base64,iVBORw0KGgo="
+                            },
+                            "index": 0
+                        },
+                        {
+                            "type": "image_url",
+                            "image_url": "data:image/webp;base64,UklGRg==",
+                            "index": 1
+                        }
+                    ]
+                }
+            }]
+        }))
+        .expect("valid OpenAI-compatible image response");
+        let message = response.choices[0]
+            .message
+            .as_ref()
+            .expect("response message");
+
+        assert_eq!(
+            extract_primary_content(&message.content, &message.extra).as_deref(),
+            Some(
+                "Generated image\n\n![image](data:image/png;base64,iVBORw0KGgo=)\n\n![image](data:image/webp;base64,UklGRg==)"
+            )
         );
     }
 


### PR DESCRIPTION
## 变更说明

- 支持 OpenAI 兼容 Chat Completions 响应中的 `images[].image_url.url` 图片字段。
- 同时处理流式 `choices[].delta.images` 和非流式 `choices[].message.images`。
- 在响应同时包含文本和图片时保留两者，并按原有消息内容顺序输出。
- 复用现有 inline media 管线，将 Base64 data URI 解码、持久化并注册为消息附件，避免原始 Base64 跨越 IPC 或保留在数据库正文中。

## 问题背景

部分通过 OpenAI 兼容端点提供的绘图模型不支持 `/images/generations`，只能通过 `/chat/completions` 生成图片。此类端点可能将结果返回在以下扩展字段中：

```json
{
  "choices": [
    {
      "delta": {
        "content": null,
        "images": [
          {
            "type": "image_url",
            "image_url": {
              "url": "data:image/jpeg;base64,..."
            }
          }
        ]
      }
    }
  ]
}
```

此前这些字段虽然会被反序列化到 OpenAI 兼容响应的扩展字段中，但不会被内容提取逻辑读取。AQBot 最终只能取得 token usage，正文仍为空，因此在收到 `[DONE]` 后报错 `Provider returned empty response`。

## 实现方式

- 从响应扩展字段中提取 `images` 数组。
- 支持对象形式和字符串形式的 `image_url`。
- 仅接收 `data:image/` 类型的内联图片，转换为现有 Markdown 图片内容。

## 测试

- 新增流式 `delta.images` 图片响应解析测试。
- 新增非流式文本与多图片组合响应测试。
- 已运行：

```text
cargo test --package aqbot-providers --target x86_64-pc-windows-gnu openai_compatible
```

- 结果：3 passed，0 failed。
- 已使用实际 OpenAI 兼容中转端点和 `gemini-3.1-flash-image` 模型完成手动验证。
