### PR TITLE
fix(responses): 修复 DeepSeek 官方 Responses API 思考过程不显示

### DIFF
--- a/src-tauri/crates/providers/src/openai_responses.rs
+++ b/src-tauri/crates/providers/src/openai_responses.rs
@@ -568,7 +568,9 @@ impl ResponsesStreamState {
                     finish_reason: None,
                 }
             }
-            "response.reasoning.delta" | "response.reasoning_summary_text.delta" => {
+            "response.reasoning.delta"
+            | "response.reasoning_summary_text.delta"
+            | "response.reasoning_text.delta" => {
                 let evt: StreamReasoningDeltaEvent = parse_stream_event(json)?;
                 let thinking = evt.delta.ok_or_else(|| {
                     AQBotError::Provider("Missing Responses reasoning delta".into())

--- a/src-tauri/crates/providers/src/sse.rs
+++ b/src-tauri/crates/providers/src/sse.rs
@@ -439,6 +439,49 @@ mod adapter_tests {
     }
 
     #[tokio::test]
+    async fn responses_deepseek_reasoning_text_delta_is_forwarded() {
+        let body = concat!(
+            "event: response.reasoning_text.delta\ndata: {\"type\":\"response.reasoning_text.delta\",\"delta\":\"The user\"}\n\n",
+            "event: response.reasoning_text.delta\ndata: {\"type\":\"response.reasoning_text.delta\",\"delta\":\" greets me.\"}\n\n",
+            "event: response.output_text.delta\ndata: {\"delta\":\"Hello\"}\n\n",
+            "event: response.completed\ndata: {\"response\":{\"usage\":{\"input_tokens\":3,\"output_tokens\":2,\"total_tokens\":5},\"output\":[]}}"
+        );
+        let results = collect("responses", body.as_bytes(), false).await;
+        let thinking: String = results
+            .iter()
+            .filter_map(|result| result.as_ref().ok())
+            .filter_map(|chunk| chunk.thinking.as_deref())
+            .collect();
+        assert_eq!(thinking, "The user greets me.");
+        let content: String = results
+            .iter()
+            .filter_map(|result| result.as_ref().ok())
+            .filter_map(|chunk| chunk.content.as_deref())
+            .collect();
+        assert_eq!(content, "Hello");
+        assert!(results.last().unwrap().as_ref().unwrap().done);
+    }
+
+    #[tokio::test]
+    async fn responses_reasoning_delta_variants_are_forwarded() {
+        for event in [
+            "response.reasoning.delta",
+            "response.reasoning_summary_text.delta",
+            "response.reasoning_text.delta",
+        ] {
+            let body = format!(
+                "event: {event}\ndata: {{\"delta\":\"Think\"}}\n\nevent: response.completed\ndata: {{\"response\":{{\"output\":[]}}}}"
+            );
+            let results = collect("responses", body.as_bytes(), false).await;
+            assert_eq!(
+                results[0].as_ref().unwrap().thinking.as_deref(),
+                Some("Think"),
+                "{event}"
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn all_http_adapters_propagate_explicit_stream_errors() {
         for (name, event) in [
             ("openai", ""),


### PR DESCRIPTION
## 变更说明

- 支持 **DeepSeek 官方 Responses API**（`https://api.deepseek.com`）的流式思考过程事件 `response.reasoning_text.delta`，将思维链文本作为 `thinking` 增量下发给上层。
- 保持与 OpenAI 既有事件名 `response.reasoning.delta`、`response.reasoning_summary_text.delta` 的兼容。
- 注意：本改动针对 DeepSeek 官方 API 的事件格式，格式以对应服务商文档为准。

## 问题背景

AQBot 使用 **DeepSeek 官方 Responses API** 调用 DeepSeek 时，界面上始终不显示思考过程文本，但接口本身返回了完整的思维链。

以官方 API 的 `deepseek-flash` 为例，非流式响应中已包含 `reasoning` 输出项：

```json
{
  "output": [
    {
      "type": "reasoning",
      "id": "e34ca71e-dbd9-4524-90dc-3cd7dc9effac",
      "status": "completed",
      "content": [
        { "type": "reasoning_text", "text": "The user just said ..." }
      ],
      "summary": []
    },
    { "type": "message", "status": "completed", "content": [ { "type": "output_text", "text": "你好！很高兴见到你 😊" } ] }
  ]
}
```

流式模式下，**DeepSeek 官方 API** 使用事件 `response.reasoning_text.delta` 逐步下发思维链。而解析器 `ResponsesStreamState::apply` 仅匹配了 `response.reasoning.delta` 与 `response.reasoning_summary_text.delta`，未匹配 DeepSeek 官方的事件名，导致该事件被静默丢弃，因此界面上看不到思考过程。

## 实现方式

- 在 `openai_responses.rs` 的流式事件分发中，为思维链增量匹配新增 `response.reasoning_text.delta`。
- 复用现有 `StreamReasoningDeltaEvent`（已含 `delta` 字段），无需新增响应类型或改动上层管线。
- 事件随后沿既有路径被包装为 `<think data-aqbot="1">` 块合并进 `content`，前端渲染逻辑无需改动。

## 测试

- 新增 `responses_deepseek_reasoning_text_delta_is_forwarded`：模拟 DeepSeek 思维链增量 + 正文输出 + 终止事件，断言 `thinking` 与 `content` 分别正确。
- 新增 `responses_reasoning_delta_variants_are_forwarded`：覆盖三种reasoning增量事件名均能正确下发。
- 已运行：

```text
cargo test --package aqbot-providers --target x86_64-pc-windows-gnu
```

- 结果：全部通过。
- 已使用 **DeepSeek 官方 Responses API** 实机验证，开启思考后界面正常显示思考过程文本。
